### PR TITLE
Add spaces to italic parts of readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,10 +30,10 @@ This immediately makes what seems like the most straightforward way to copy data
 \* *If you're currently thinking to yourself "bah! what's the issue? surely an uninit u8 is just any random bit pattern
 and that's fine we don't care," [check out this blog post](https://www.ralfj.de/blog/2019/07/14/uninit.html) by
 @RalfJung, one of the people leading the effort to better define Rust's memory and execution model. As is explored
-in that blog post, an*uninit*piece of memory is not simply*an arbitrary bit pattern*, it is a wholly separate
+in that blog post, an* uninit *piece of memory is not simply* an arbitrary bit pattern, *it is a wholly separate
 state about a piece of memory, outside of its value, which lets the compiler perform optimizations that reorder,
 delete, and otherwise change the actual execution flow of your program in ways that cannot be described simply
-by "the value could have*some*possible bit pattern". LLVM and Clang are changing themselves to require special
+by "the value could have* some *possible bit pattern". LLVM and Clang are changing themselves to require special
 `noundef` attribute to perform many important optimizations that are otherwise unsound. For a concrete example
 of the sorts of problems this can cause, [see this issue @scottmcm hit](https://github.com/rust-lang/rust/pull/98919#issuecomment-1186106387).*
 


### PR DESCRIPTION
### Checklist

* [x] I have read the [Contributor Guide](../../CONTRIBUTING.md)
* [x] I have read and agree to the [Code of Conduct](../../CODE_OF_CONDUCT.md)
* [x] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

Just a small readability fix for the readme: An italic section was missing some spaces:

> *an*uninit*piece of memory is not simply*an arbitrary bit pattern,*it is a wholly separate state*

→

> *an* uninit *piece of memory is not simply* an arbitrary bit pattern, *it is a wholly separate state*