### PR TITLE
Add read helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `[]_exact` versions of copy functions which ensure that the copy will actually start at the
 provided start_offset, otherwise returning an error.
 - Add `CopyError::RequestedOffsetUnaligned` to support the above error case.
+- Add `read_[]` and `get_maybe_uninit_[]_mut` helper functions for accessing copied data.
 
 ## [0.3.1] - 2022-10-16
 

--- a/src/copy.rs
+++ b/src/copy.rs
@@ -8,7 +8,7 @@ pub struct CopyRecord {
     ///
     /// Not necessarily equal to the `start_offset` provided to the copy function, since this offset
     /// includes necessary padding to assure alignment.
-    pub copy_start_offset: usize,
+    pub start_offset: usize,
 
     /// The offset from the start of the allocation, in bytes, at which the
     /// copy operation no longer wrote data.
@@ -16,13 +16,14 @@ pub struct CopyRecord {
     /// This does not include any padding at the end necessary to maintain
     /// alignment requirements.
     ///
-    /// Unless you really know what you're doing, you *likely* want to use `end_offset_padded` instead.
-    pub copy_end_offset: usize,
+    /// Unless you have a good reason otherwise, you *likely* want to use
+    /// [`end_offset_padded`][CopyRecord::end_offset_padded] instead.
+    pub end_offset: usize,
 
     /// The offset from the start of the allocation, in bytes, at which the
     /// copy operation no longer wrote data, plus any padding necessary to
     /// maintain derived alignment requirements.
-    pub copy_end_offset_padded: usize,
+    pub end_offset_padded: usize,
 }
 
 impl From<ComputedOffsets> for CopyRecord {
@@ -34,9 +35,9 @@ impl From<ComputedOffsets> for CopyRecord {
         }: ComputedOffsets,
     ) -> Self {
         Self {
-            copy_start_offset: start,
-            copy_end_offset: end,
-            copy_end_offset_padded: end_padded,
+            start_offset: start,
+            end_offset: end,
+            end_offset_padded: end_padded,
         }
     }
 }
@@ -54,7 +55,7 @@ impl From<ComputedOffsets> for CopyRecord {
 /// This function is safe on its own, however it is very possible to do unsafe
 /// things if you read the copied data in the wrong way. See the
 /// [crate-level Safety documentation][`crate#safety`] for more.
-#[inline]
+#[inline(always)]
 pub fn copy_to_offset_exact<T: Copy, S: Slab>(
     src: &T,
     dst: &mut S,
@@ -65,22 +66,24 @@ pub fn copy_to_offset_exact<T: Copy, S: Slab>(
 
 /// Copies `src` into the memory represented by `dst` starting at *exactly*
 /// `start_offset` bytes past the start of `dst` and with minimum alignment
-/// `min_alignment`.
+/// `min_alignment`. If the requested parameters would be violated by computed alignment requirements,
+/// an error will be returned.
 ///
 /// - `start_offset` is the offset into the allocation represented by `dst`, in bytes,
 /// where the first byte of the copied data will be placed. If the requested
 /// start offset does not satisfy computed alignment requirements, an error will
 /// be returned and no data will be copied.
-/// - `min_alignment` is the minimum alignment to which the copy will be aligned. The
-/// copy may not actually be aligned to `min_alignment` depending on the alignment requirements
-/// of `T` (the actual alignment will be the greater between `align_of::<T>` and `min_align.next_power_of_two()`).
+/// - `min_alignment` is the minimum alignment that you are requesting the copy be aligned to. The
+/// copy may be aligned greater than `min_alignment` depending on the alignment requirements
+/// of `T` (the actual alignment will be the greater of the two between `align_of::<T>()` and
+/// `min_align.next_power_of_two()`).
 ///
 /// # Safety
 ///
 /// This function is safe on its own, however it is very possible to do unsafe
 /// things if you read the copied data in the wrong way. See the
 /// [crate-level Safety documentation][`crate#safety`] for more.
-#[inline]
+#[inline(always)]
 pub fn copy_to_offset_with_align_exact<T: Copy, S: Slab>(
     src: &T,
     dst: &mut S,
@@ -209,11 +212,12 @@ pub fn copy_from_slice_to_offset_exact<T: Copy, S: Slab>(
 /// where the first byte of the copied data will be placed. If the requested
 /// start offset does not satisfy computed alignment requirements, an error will
 /// be returned and no data will be copied.
-/// - `min_alignment` is the minimum alignment to which the copy will be aligned. The
-/// copy may not actually be aligned to `min_alignment` depending on the alignment requirements
-/// of `T` (the actual alignment will be the greater between `align_of::<T>` and `min_align.next_power_of_two()`).
+/// - `min_alignment` is the minimum alignment that you are requesting the copy be aligned to. The
+/// copy may be aligned greater than `min_alignment` depending on the alignment requirements
+/// of `T` (the actual alignment will be the greater of the two between `align_of::<T>()` and
+/// `min_align.next_power_of_two()`).
 ///     - The whole data of the slice will be copied directly, so, alignment between elements
-/// ignores `min_alignment`.
+///     ignores `min_alignment`.
 ///
 /// # Safety
 ///
@@ -280,11 +284,12 @@ pub fn copy_from_slice_to_offset<T: Copy, S: Slab>(
 /// the actual beginning of the copied data may not be exactly at `start_offset` if
 /// padding bytes are needed to satisfy alignment requirements. The actual beginning
 /// of the copied bytes is contained in the returned [`CopyRecord`].
-/// - `min_alignment` is the minimum alignment to which the copy will be aligned. The
-/// copy may not actually be aligned to `min_alignment` depending on the alignment requirements
-/// of `T` (the actual alignment will be the greater between `align_of::<T>` and `min_align.next_power_of_two()`).
-///     - The whole data of the slice will be copied directly, so, alignment between elements
-/// ignores `min_alignment`.
+/// - `min_alignment` is the minimum alignment that you are requesting the copy be aligned to. The
+/// copy may be aligned greater than `min_alignment` depending on the alignment requirements
+/// of `T` (the actual alignment will be the greater of the two between `align_of::<T>()` and
+/// `min_align.next_power_of_two()`).
+///     - The whole data of the slice will be copied directly, so alignment between elements
+///     ignores `min_alignment`.
 ///
 /// # Safety
 ///
@@ -331,9 +336,10 @@ pub fn copy_from_slice_to_offset_with_align<T: Copy, S: Slab>(
 /// the actual beginning of the copied data may not be exactly at `start_offset` if
 /// padding bytes are needed to satisfy alignment requirements. The actual beginning
 /// of the copied bytes is contained in the returned [`CopyRecord`]s.
-/// - `min_alignment` is the minimum alignment to which the copy will be aligned. The
-/// copy may not actually be aligned to `min_alignment` depending on the alignment requirements
-/// of `T` (the actual alignment will be the greater between `align_of::<T>` and `min_align.next_power_of_two()`).
+/// - `min_alignment` is the minimum alignment that you are requesting the copy be aligned to. The
+/// copy may be aligned greater than `min_alignment` depending on the alignment requirements
+/// of `T` (the actual alignment will be the greater of the two between `align_of::<T>()` and
+/// `min_align.next_power_of_two()`).
 /// - For this variation, `min_alignment` will also be respected *between* elements yielded by
 /// the iterator. To copy inner elements aligned only to `align_of::<T>()` (i.e. with the layout of
 /// an `[T]`), see [`copy_from_iter_to_offset_with_align_packed`].
@@ -355,7 +361,7 @@ pub fn copy_from_iter_to_offset_with_align<T: Copy, Iter: Iterator<Item = T>, S:
 
     src.map(|item| {
         let copy_record = copy_to_offset_with_align(&item, dst, offset, min_alignment)?;
-        offset = copy_record.copy_end_offset;
+        offset = copy_record.end_offset;
         Ok(copy_record)
     })
     .collect::<Result<Vec<_>, _>>()
@@ -383,14 +389,14 @@ pub fn copy_from_iter_to_offset_with_align_packed<T: Copy, Iter: Iterator<Item =
     let mut prev_record = first_record;
 
     for item in src {
-        let copy_record = copy_to_offset_with_align(&item, dst, prev_record.copy_end_offset, 1)?;
+        let copy_record = copy_to_offset_with_align(&item, dst, prev_record.end_offset, 1)?;
         prev_record = copy_record;
     }
 
     Ok(Some(CopyRecord {
-        copy_start_offset: first_record.copy_start_offset,
-        copy_end_offset: prev_record.copy_end_offset,
-        copy_end_offset_padded: prev_record.copy_end_offset_padded,
+        start_offset: first_record.start_offset,
+        end_offset: prev_record.end_offset,
+        end_offset_padded: prev_record.end_offset_padded,
     }))
 }
 
@@ -418,13 +424,13 @@ pub fn copy_from_iter_to_offset_with_align_exact_packed<
 
     for item in src {
         let copy_record =
-            copy_to_offset_with_align_exact(&item, dst, prev_record.copy_end_offset, 1)?;
+            copy_to_offset_with_align_exact(&item, dst, prev_record.end_offset, 1)?;
         prev_record = copy_record;
     }
 
     Ok(Some(CopyRecord {
-        copy_start_offset: first_record.copy_start_offset,
-        copy_end_offset: prev_record.copy_end_offset,
-        copy_end_offset_padded: prev_record.copy_end_offset_padded,
+        start_offset: first_record.start_offset,
+        end_offset: prev_record.end_offset,
+        end_offset_padded: prev_record.end_offset_padded,
     }))
 }

--- a/src/copy.rs
+++ b/src/copy.rs
@@ -88,7 +88,7 @@ pub fn copy_to_offset_with_align_exact<T: Copy, S: Slab>(
     min_alignment: usize,
 ) -> Result<CopyRecord, Error> {
     let t_layout = Layout::new::<T>();
-    let offsets = compute_offsets(&*dst, start_offset, t_layout, min_alignment, true)?;
+    let offsets = compute_and_validate_offsets(&*dst, start_offset, t_layout, min_alignment, true)?;
 
     // SAFETY: if compute_offsets succeeded, this has already been checked to be safe.
     let dst_ptr = unsafe { dst.base_ptr_mut().add(offsets.start) }.cast::<T>();
@@ -158,7 +158,7 @@ pub fn copy_to_offset_with_align<T: Copy, S: Slab>(
     min_alignment: usize,
 ) -> Result<CopyRecord, Error> {
     let t_layout = Layout::new::<T>();
-    let offsets = compute_offsets(&*dst, start_offset, t_layout, min_alignment, false)?;
+    let offsets = compute_and_validate_offsets(&*dst, start_offset, t_layout, min_alignment, false)?;
 
     // SAFETY: if compute_offsets succeeded, this has already been checked to be safe.
     let dst_ptr = unsafe { dst.base_ptr_mut().add(offsets.start) }.cast::<T>();
@@ -227,7 +227,7 @@ pub fn copy_from_slice_to_offset_with_align_exact<T: Copy, S: Slab>(
     min_alignment: usize,
 ) -> Result<CopyRecord, Error> {
     let t_layout = Layout::for_value(src);
-    let offsets = compute_offsets(&*dst, start_offset, t_layout, min_alignment, true)?;
+    let offsets = compute_and_validate_offsets(&*dst, start_offset, t_layout, min_alignment, true)?;
 
     // SAFETY: if compute_offsets succeeded, this has already been checked to be safe.
     let dst_ptr = unsafe { dst.base_ptr_mut().add(offsets.start) }.cast::<T>();
@@ -298,7 +298,7 @@ pub fn copy_from_slice_to_offset_with_align<T: Copy, S: Slab>(
     min_alignment: usize,
 ) -> Result<CopyRecord, Error> {
     let t_layout = Layout::for_value(src);
-    let offsets = compute_offsets(&*dst, start_offset, t_layout, min_alignment, false)?;
+    let offsets = compute_and_validate_offsets(&*dst, start_offset, t_layout, min_alignment, false)?;
 
     // SAFETY: if compute_offsets succeeded, this has already been checked to be safe.
     let dst_ptr = unsafe { dst.base_ptr_mut().add(offsets.start) }.cast::<T>();

--- a/src/copy.rs
+++ b/src/copy.rs
@@ -423,8 +423,7 @@ pub fn copy_from_iter_to_offset_with_align_exact_packed<
     let mut prev_record = first_record;
 
     for item in src {
-        let copy_record =
-            copy_to_offset_with_align_exact(&item, dst, prev_record.end_offset, 1)?;
+        let copy_record = copy_to_offset_with_align_exact(&item, dst, prev_record.end_offset, 1)?;
         prev_record = copy_record;
     }
 

--- a/src/copy.rs
+++ b/src/copy.rs
@@ -1,0 +1,428 @@
+use super::*;
+
+/// Record of the results of a copy operation
+#[derive(Debug, Copy, Clone)]
+pub struct CopyRecord {
+    /// The offset from the start of the allocation, in bytes, at which the
+    /// copy operation began to write data.
+    ///
+    /// Not necessarily equal to the `start_offset` provided to the copy function, since this offset
+    /// includes necessary padding to assure alignment.
+    pub copy_start_offset: usize,
+
+    /// The offset from the start of the allocation, in bytes, at which the
+    /// copy operation no longer wrote data.
+    ///
+    /// This does not include any padding at the end necessary to maintain
+    /// alignment requirements.
+    ///
+    /// Unless you really know what you're doing, you *likely* want to use `end_offset_padded` instead.
+    pub copy_end_offset: usize,
+
+    /// The offset from the start of the allocation, in bytes, at which the
+    /// copy operation no longer wrote data, plus any padding necessary to
+    /// maintain derived alignment requirements.
+    pub copy_end_offset_padded: usize,
+}
+
+impl From<ComputedOffsets> for CopyRecord {
+    fn from(
+        ComputedOffsets {
+            start,
+            end,
+            end_padded,
+        }: ComputedOffsets,
+    ) -> Self {
+        Self {
+            copy_start_offset: start,
+            copy_end_offset: end,
+            copy_end_offset_padded: end_padded,
+        }
+    }
+}
+
+/// Copies `src` into the memory represented by `dst` starting at *exactly*
+/// `start_offset` bytes past the start of `dst`
+///
+/// - `start_offset` is the offset into the allocation represented by `dst`, in bytes,
+/// where the first byte of the copied data will be placed. If the requested
+/// start offset does not satisfy computed alignment requirements, an error will
+/// be returned and no data will be copied.
+///
+/// # Safety
+///
+/// This function is safe on its own, however it is very possible to do unsafe
+/// things if you read the copied data in the wrong way. See the
+/// [crate-level Safety documentation][`crate#safety`] for more.
+#[inline]
+pub fn copy_to_offset_exact<T: Copy, S: Slab>(
+    src: &T,
+    dst: &mut S,
+    start_offset: usize,
+) -> Result<CopyRecord, Error> {
+    copy_to_offset_with_align_exact(src, dst, start_offset, 1)
+}
+
+/// Copies `src` into the memory represented by `dst` starting at *exactly*
+/// `start_offset` bytes past the start of `dst` and with minimum alignment
+/// `min_alignment`.
+///
+/// - `start_offset` is the offset into the allocation represented by `dst`, in bytes,
+/// where the first byte of the copied data will be placed. If the requested
+/// start offset does not satisfy computed alignment requirements, an error will
+/// be returned and no data will be copied.
+/// - `min_alignment` is the minimum alignment to which the copy will be aligned. The
+/// copy may not actually be aligned to `min_alignment` depending on the alignment requirements
+/// of `T` (the actual alignment will be the greater between `align_of::<T>` and `min_align.next_power_of_two()`).
+///
+/// # Safety
+///
+/// This function is safe on its own, however it is very possible to do unsafe
+/// things if you read the copied data in the wrong way. See the
+/// [crate-level Safety documentation][`crate#safety`] for more.
+#[inline]
+pub fn copy_to_offset_with_align_exact<T: Copy, S: Slab>(
+    src: &T,
+    dst: &mut S,
+    start_offset: usize,
+    min_alignment: usize,
+) -> Result<CopyRecord, Error> {
+    let t_layout = Layout::new::<T>();
+    let offsets = compute_offsets(&*dst, start_offset, t_layout, min_alignment, true)?;
+
+    // SAFETY: if compute_offsets succeeded, this has already been checked to be safe.
+    let dst_ptr = unsafe { dst.base_ptr_mut().add(offsets.start) }.cast::<T>();
+
+    // SAFETY:
+    // - src is valid as we have a reference to it
+    // - dst is valid so long as requirements for `slab` were met, i.e.
+    // we have unique access to the region described and that it is valid for the duration
+    // of 'a.
+    // - areas not overlapping as long as safety requirements of creation of `self` were met,
+    // i.e. that we have exclusive access to the region of memory described.
+    // - dst aligned at least to align_of::<T>()
+    // - checked that copy stays within bounds of our allocation
+    unsafe {
+        core::ptr::copy_nonoverlapping(src as *const T, dst_ptr, 1);
+    }
+
+    Ok(offsets.into())
+}
+
+/// Copies `src` into the memory represented by `dst` starting at a minimum location
+/// of `start_offset` bytes past the start of `dst`.
+///
+/// - `start_offset` is the offset into the allocation represented by `dst`,
+/// in bytes, before which any copied data will *certainly not* be placed. However,
+/// the actual beginning of the copied data may not be exactly at `start_offset` if
+/// padding bytes are needed to satisfy alignment requirements. The actual beginning
+/// of the copied bytes is contained in the returned [`CopyRecord`].
+///
+/// # Safety
+///
+/// This function is safe on its own, however it is very possible to do unsafe
+/// things if you read the copied data in the wrong way. See the
+/// [crate-level Safety documentation][`crate#safety`] for more.
+#[inline]
+pub fn copy_to_offset<T: Copy, S: Slab>(
+    src: &T,
+    dst: &mut S,
+    start_offset: usize,
+) -> Result<CopyRecord, Error> {
+    copy_to_offset_with_align(src, dst, start_offset, 1)
+}
+
+/// Copies `src` into the memory represented by `dst` starting at a minimum location
+/// of `start_offset` bytes past the start of `dst` and with minimum alignment
+/// `min_alignment`.
+///
+/// - `start_offset` is the offset into the allocation represented by `dst`,
+/// in bytes, before which any copied data will *certainly not* be placed. However,
+/// the actual beginning of the copied data may not be exactly at `start_offset` if
+/// padding bytes are needed to satisfy alignment requirements. The actual beginning
+/// of the copied bytes is contained in the returned [`CopyRecord`].
+/// - `min_alignment` is the minimum alignment to which the copy will be aligned. The
+/// copy may not actually be aligned to `min_alignment` depending on the alignment requirements
+/// of `T` (the actual alignment will be the greater between `align_of::<T>` and `min_align.next_power_of_two()`).
+///
+/// # Safety
+///
+/// This function is safe on its own, however it is very possible to do unsafe
+/// things if you read the copied data in the wrong way. See the
+/// [crate-level Safety documentation][`crate#safety`] for more.
+#[inline]
+pub fn copy_to_offset_with_align<T: Copy, S: Slab>(
+    src: &T,
+    dst: &mut S,
+    start_offset: usize,
+    min_alignment: usize,
+) -> Result<CopyRecord, Error> {
+    let t_layout = Layout::new::<T>();
+    let offsets = compute_offsets(&*dst, start_offset, t_layout, min_alignment, false)?;
+
+    // SAFETY: if compute_offsets succeeded, this has already been checked to be safe.
+    let dst_ptr = unsafe { dst.base_ptr_mut().add(offsets.start) }.cast::<T>();
+
+    // SAFETY:
+    // - src is valid as we have a reference to it
+    // - dst is valid so long as requirements for `slab` were met, i.e.
+    // we have unique access to the region described and that it is valid for the duration
+    // of 'a.
+    // - areas not overlapping as long as safety requirements of creation of `self` were met,
+    // i.e. that we have exclusive access to the region of memory described.
+    // - dst aligned at least to align_of::<T>()
+    // - checked that copy stays within bounds of our allocation
+    unsafe {
+        core::ptr::copy_nonoverlapping(src as *const T, dst_ptr, 1);
+    }
+
+    Ok(offsets.into())
+}
+
+/// Copies from `slice` into the memory represented by `dst` starting at *exactly*
+/// `start_offset` bytes past the start of `self`.
+///
+/// - `start_offset` is the offset into the allocation represented by `dst`, in bytes,
+/// where the first byte of the copied data will be placed. If the requested
+/// start offset does not satisfy computed alignment requirements, an error will
+/// be returned and no data will be copied.
+///
+/// # Safety
+///
+/// This function is safe on its own, however it is very possible to do unsafe
+/// things if you read the copied data in the wrong way. See the
+/// [crate-level Safety documentation][`crate#safety`] for more.
+#[inline]
+pub fn copy_from_slice_to_offset_exact<T: Copy, S: Slab>(
+    src: &[T],
+    dst: &mut S,
+    start_offset: usize,
+) -> Result<CopyRecord, Error> {
+    copy_from_slice_to_offset_with_align(src, dst, start_offset, 1)
+}
+
+/// Copies from `slice` into the memory represented by `dst` starting at *exactly*
+/// `start_offset` bytes past the start of `dst` and with minimum alignment `min_alignment`.
+///
+/// - `start_offset` is the offset into the allocation represented by `dst`, in bytes,
+/// where the first byte of the copied data will be placed. If the requested
+/// start offset does not satisfy computed alignment requirements, an error will
+/// be returned and no data will be copied.
+/// - `min_alignment` is the minimum alignment to which the copy will be aligned. The
+/// copy may not actually be aligned to `min_alignment` depending on the alignment requirements
+/// of `T` (the actual alignment will be the greater between `align_of::<T>` and `min_align.next_power_of_two()`).
+///     - The whole data of the slice will be copied directly, so, alignment between elements
+/// ignores `min_alignment`.
+///
+/// # Safety
+///
+/// This function is safe on its own, however it is very possible to do unsafe
+/// things if you read the copied data in the wrong way. See the
+/// [crate-level Safety documentation][`crate#safety`] for more.
+#[inline]
+pub fn copy_from_slice_to_offset_with_align_exact<T: Copy, S: Slab>(
+    src: &[T],
+    dst: &mut S,
+    start_offset: usize,
+    min_alignment: usize,
+) -> Result<CopyRecord, Error> {
+    let t_layout = Layout::for_value(src);
+    let offsets = compute_offsets(&*dst, start_offset, t_layout, min_alignment, true)?;
+
+    // SAFETY: if compute_offsets succeeded, this has already been checked to be safe.
+    let dst_ptr = unsafe { dst.base_ptr_mut().add(offsets.start) }.cast::<T>();
+
+    // SAFETY:
+    // - src is valid as we have a reference to it
+    // - dst is valid so long as requirements for `slab` were met, i.e.
+    // we have unique access to the region described and that it is valid for the duration
+    // of 'a.
+    // - areas not overlapping as long as safety requirements of creation of `self` were met,
+    // i.e. that we have exclusive access to the region of memory described.
+    // - dst aligned at least to align_of::<T>()
+    // - checked that copy stays within bounds of our allocation
+    unsafe {
+        core::ptr::copy_nonoverlapping(src.as_ptr(), dst_ptr, src.len());
+    }
+
+    Ok(offsets.into())
+}
+
+/// Copies from `slice` into the memory represented by `dst` starting at a minimum location
+/// of `start_offset` bytes past the start of `self`.
+///
+/// - `start_offset` is the offset into the allocation represented by `dst`,
+/// in bytes, before which any copied data will *certainly not* be placed. However,
+/// the actual beginning of the copied data may not be exactly at `start_offset` if
+/// padding bytes are needed to satisfy alignment requirements. The actual beginning
+/// of the copied bytes is contained in the returned [`CopyRecord`].
+///
+/// # Safety
+///
+/// This function is safe on its own, however it is very possible to do unsafe
+/// things if you read the copied data in the wrong way. See the
+/// [crate-level Safety documentation][`crate#safety`] for more.
+#[inline]
+pub fn copy_from_slice_to_offset<T: Copy, S: Slab>(
+    src: &[T],
+    dst: &mut S,
+    start_offset: usize,
+) -> Result<CopyRecord, Error> {
+    copy_from_slice_to_offset_with_align(src, dst, start_offset, 1)
+}
+
+/// Copies from `slice` into the memory represented by `dst` starting at a minimum location
+/// of `start_offset` bytes past the start of `dst`.
+///
+/// - `start_offset` is the offset into the allocation represented by `dst`,
+/// in bytes, before which any copied data will *certainly not* be placed. However,
+/// the actual beginning of the copied data may not be exactly at `start_offset` if
+/// padding bytes are needed to satisfy alignment requirements. The actual beginning
+/// of the copied bytes is contained in the returned [`CopyRecord`].
+/// - `min_alignment` is the minimum alignment to which the copy will be aligned. The
+/// copy may not actually be aligned to `min_alignment` depending on the alignment requirements
+/// of `T` (the actual alignment will be the greater between `align_of::<T>` and `min_align.next_power_of_two()`).
+///     - The whole data of the slice will be copied directly, so, alignment between elements
+/// ignores `min_alignment`.
+///
+/// # Safety
+///
+/// This function is safe on its own, however it is very possible to do unsafe
+/// things if you read the copied data in the wrong way. See the
+/// [crate-level Safety documentation][`crate#safety`] for more.
+#[inline]
+pub fn copy_from_slice_to_offset_with_align<T: Copy, S: Slab>(
+    src: &[T],
+    dst: &mut S,
+    start_offset: usize,
+    min_alignment: usize,
+) -> Result<CopyRecord, Error> {
+    let t_layout = Layout::for_value(src);
+    let offsets = compute_offsets(&*dst, start_offset, t_layout, min_alignment, false)?;
+
+    // SAFETY: if compute_offsets succeeded, this has already been checked to be safe.
+    let dst_ptr = unsafe { dst.base_ptr_mut().add(offsets.start) }.cast::<T>();
+
+    // SAFETY:
+    // - src is valid as we have a reference to it
+    // - dst is valid so long as requirements for `slab` were met, i.e.
+    // we have unique access to the region described and that it is valid for the duration
+    // of 'a.
+    // - areas not overlapping as long as safety requirements of creation of `self` were met,
+    // i.e. that we have exclusive access to the region of memory described.
+    // - dst aligned at least to align_of::<T>()
+    // - checked that copy stays within bounds of our allocation
+    unsafe {
+        core::ptr::copy_nonoverlapping(src.as_ptr(), dst_ptr, src.len());
+    }
+
+    Ok(offsets.into())
+}
+
+/// Copies from `src` iterator into the memory represented by `dst` starting at a minimum location
+/// of `start_offset` bytes past the start of `dst`.
+///
+/// Returns a vector of [`CopyRecord`]s, one for each item in the `src` iterator.
+///
+/// - `start_offset` is the offset into the allocation represented by `dst`,
+/// in bytes, before which any copied data will *certainly not* be placed. However,
+/// the actual beginning of the copied data may not be exactly at `start_offset` if
+/// padding bytes are needed to satisfy alignment requirements. The actual beginning
+/// of the copied bytes is contained in the returned [`CopyRecord`]s.
+/// - `min_alignment` is the minimum alignment to which the copy will be aligned. The
+/// copy may not actually be aligned to `min_alignment` depending on the alignment requirements
+/// of `T` (the actual alignment will be the greater between `align_of::<T>` and `min_align.next_power_of_two()`).
+/// - For this variation, `min_alignment` will also be respected *between* elements yielded by
+/// the iterator. To copy inner elements aligned only to `align_of::<T>()` (i.e. with the layout of
+/// an `[T]`), see [`copy_from_iter_to_offset_with_align_packed`].
+///
+/// # Safety
+///
+/// This function is safe on its own, however it is very possible to do unsafe
+/// things if you read the copied data in the wrong way. See the
+/// [crate-level Safety documentation][`crate#safety`] for more.
+#[cfg(feature = "std")]
+#[inline]
+pub fn copy_from_iter_to_offset_with_align<T: Copy, Iter: Iterator<Item = T>, S: Slab>(
+    src: Iter,
+    dst: &mut S,
+    start_offset: usize,
+    min_alignment: usize,
+) -> Result<Vec<CopyRecord>, Error> {
+    let mut offset = start_offset;
+
+    src.map(|item| {
+        let copy_record = copy_to_offset_with_align(&item, dst, offset, min_alignment)?;
+        offset = copy_record.copy_end_offset;
+        Ok(copy_record)
+    })
+    .collect::<Result<Vec<_>, _>>()
+}
+
+/// Like [`copy_from_iter_to_offset_with_align`] except that
+/// alignment between elements yielded by the iterator will ignore `min_alignment`
+/// and rather only be aligned to the alignment of `T`.
+///
+/// Because of this, only one [`CopyRecord`] is returned specifying the record of the
+/// entire block of copied data. If the `src` iterator is empty, returns `None`.
+#[inline]
+pub fn copy_from_iter_to_offset_with_align_packed<T: Copy, Iter: Iterator<Item = T>, S: Slab>(
+    mut src: Iter,
+    dst: &mut S,
+    start_offset: usize,
+    min_alignment: usize,
+) -> Result<Option<CopyRecord>, Error> {
+    let first_record = if let Some(first_item) = src.next() {
+        copy_to_offset_with_align(&first_item, dst, start_offset, min_alignment)?
+    } else {
+        return Ok(None);
+    };
+
+    let mut prev_record = first_record;
+
+    for item in src {
+        let copy_record = copy_to_offset_with_align(&item, dst, prev_record.copy_end_offset, 1)?;
+        prev_record = copy_record;
+    }
+
+    Ok(Some(CopyRecord {
+        copy_start_offset: first_record.copy_start_offset,
+        copy_end_offset: prev_record.copy_end_offset,
+        copy_end_offset_padded: prev_record.copy_end_offset_padded,
+    }))
+}
+
+/// Like [`copy_from_iter_to_offset_with_align_packed`] except that it will return an error
+/// and no data will be copied if the supplied `start_offset` doesn't meet the computed alignment
+/// requirements.
+#[inline]
+pub fn copy_from_iter_to_offset_with_align_exact_packed<
+    T: Copy,
+    Iter: Iterator<Item = T>,
+    S: Slab,
+>(
+    mut src: Iter,
+    dst: &mut S,
+    start_offset: usize,
+    min_alignment: usize,
+) -> Result<Option<CopyRecord>, Error> {
+    let first_record = if let Some(first_item) = src.next() {
+        copy_to_offset_with_align_exact(&first_item, dst, start_offset, min_alignment)?
+    } else {
+        return Ok(None);
+    };
+
+    let mut prev_record = first_record;
+
+    for item in src {
+        let copy_record =
+            copy_to_offset_with_align_exact(&item, dst, prev_record.copy_end_offset, 1)?;
+        prev_record = copy_record;
+    }
+
+    Ok(Some(CopyRecord {
+        copy_start_offset: first_record.copy_start_offset,
+        copy_end_offset: prev_record.copy_end_offset,
+        copy_end_offset_padded: prev_record.copy_end_offset_padded,
+    }))
+}

--- a/src/copy.rs
+++ b/src/copy.rs
@@ -158,7 +158,8 @@ pub fn copy_to_offset_with_align<T: Copy, S: Slab>(
     min_alignment: usize,
 ) -> Result<CopyRecord, Error> {
     let t_layout = Layout::new::<T>();
-    let offsets = compute_and_validate_offsets(&*dst, start_offset, t_layout, min_alignment, false)?;
+    let offsets =
+        compute_and_validate_offsets(&*dst, start_offset, t_layout, min_alignment, false)?;
 
     // SAFETY: if compute_offsets succeeded, this has already been checked to be safe.
     let dst_ptr = unsafe { dst.base_ptr_mut().add(offsets.start) }.cast::<T>();
@@ -298,7 +299,8 @@ pub fn copy_from_slice_to_offset_with_align<T: Copy, S: Slab>(
     min_alignment: usize,
 ) -> Result<CopyRecord, Error> {
     let t_layout = Layout::for_value(src);
-    let offsets = compute_and_validate_offsets(&*dst, start_offset, t_layout, min_alignment, false)?;
+    let offsets =
+        compute_and_validate_offsets(&*dst, start_offset, t_layout, min_alignment, false)?;
 
     // SAFETY: if compute_offsets succeeded, this has already been checked to be safe.
     let dst_ptr = unsafe { dst.base_ptr_mut().add(offsets.start) }.cast::<T>();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -145,7 +145,7 @@ pub use read::*;
 /// trait for the extra flexibility having a trait we own provides: namely, the ability
 /// to implement it on foreign types.
 ///
-/// It is implemented for a couple of built-in slab providers, as well as for `[MaybeUnint<u8>]`,
+/// It is implemented for a couple of built-in slab providers, as well as for `[MaybeUninit<u8>]`,
 /// but the idea is that you can also implement this for your own data structure which can
 /// serve as a slab and then use that structure directly with `presser`'s helpers.
 ///
@@ -262,7 +262,7 @@ pub unsafe trait Slab {
     {
         let maybe_uninit_slice = &self.as_maybe_uninit_bytes()[range];
         // SAFETY: same requirements as function-level safety assuming the requirements
-        // for creating `self` are met since `MaybeUnint<T>` has same layout as `T`
+        // for creating `self` are met since `MaybeUninit<T>` has same layout as `T`
         unsafe {
             core::slice::from_raw_parts(
                 maybe_uninit_slice.as_ptr().cast(),
@@ -294,7 +294,7 @@ pub unsafe trait Slab {
     {
         let maybe_uninit_slice = &mut self.as_maybe_uninit_bytes_mut()[range];
         // SAFETY: same requirements as function-level safety assuming the requirements
-        // for creating `self` are met since `MaybeUnint<T>` has same layout as `T`
+        // for creating `self` are met since `MaybeUninit<T>` has same layout as `T`
         unsafe {
             core::slice::from_raw_parts_mut(
                 maybe_uninit_slice.as_mut_ptr().cast(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -381,7 +381,7 @@ pub enum Error {
     OffsetOutOfBounds,
     /// Computed invalid layout for copy operation, probably caused by incredibly large size, offset, or min-alignment parameters
     InvalidLayout,
-    /// The requested offset was unalignd. In a read operation, this means the provided offset into the buffer was not properly aligned
+    /// The requested offset was unaligned. In a read operation, this means the provided offset into the buffer was not properly aligned
     /// for the requested type.
     ///
     /// In an `exact` variant copy function, the computed copy start offset did not match the requested start offset,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,11 +78,11 @@
 //! // `my_data` may be placed at a different offset than requested. so, we check the returned
 //! // `CopyRecord` to check the actual start offset of the copied data.
 //! let actual_start_offset = copy_record.copy_start_offset;
-//! 
+//!
 //! // we may later (*unsafely*) read back our data. note that the read helpers provided by presser
 //! // are mostly unsafe. They do help protect you from some common footguns, but you still ultimately need
 //! // to guarantee you put the proper data where you're telling it you put the proper data.
-//! let my_copied_data_in_my_buffer: &MyDataStruct = unsafe { 
+//! let my_copied_data_in_my_buffer: &MyDataStruct = unsafe {
 //!     presser::read_at_offset(&slab, actual_start_offset)?
 //! };
 //! ```
@@ -108,7 +108,7 @@
 //! relies on those newly-uninit bytes being initialized to be valid (for example, taking a `&[u8]` slice of the `Vec`
 //! which includes those bytes, ***even if your code never actually reads from that slice***)
 //! is now instant **undefined behavior**.
-//! 
+//!
 //! \* *Note: this is unsafe because, as exemplified, you may copy uninit data into the buffer. Hence, care should
 //! be taken when implementing [`Slab`] and then providing a safe interface on top of a low level buffer type.*
 #![cfg_attr(not(feature = "std"), no_std)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -324,7 +324,10 @@ pub unsafe trait Slab {
     {
         let maybe_uninit_slice = &self.as_maybe_uninit_bytes()[range];
 
-        (maybe_uninit_slice.base_ptr().cast(), maybe_uninit_slice.len())
+        (
+            maybe_uninit_slice.base_ptr().cast(),
+            maybe_uninit_slice.len(),
+        )
     }
 
     /// View a portion of `self` as a [`c_void`] pointer and size, appropriate for sending to an FFI function
@@ -345,7 +348,10 @@ pub unsafe trait Slab {
         R: core::slice::SliceIndex<[MaybeUninit<u8>], Output = [MaybeUninit<u8>]>,
     {
         let maybe_uninit_slice = &mut self.as_maybe_uninit_bytes_mut()[range];
-        (maybe_uninit_slice.base_ptr_mut().cast(), maybe_uninit_slice.len())
+        (
+            maybe_uninit_slice.base_ptr_mut().cast(),
+            maybe_uninit_slice.len(),
+        )
     }
 }
 
@@ -677,9 +683,7 @@ impl HeapSlab {
         }
         // SAFETY: we just checked size is not 0, and we got the ptr back from alloc so we no it's
         // not null.
-        let base_ptr = unsafe {
-            NonNull::new_unchecked(std::alloc::alloc(layout))
-        };
+        let base_ptr = unsafe { NonNull::new_unchecked(std::alloc::alloc(layout)) };
         Self { base_ptr, layout }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -356,7 +356,7 @@ pub unsafe trait Slab {
 }
 
 // SAFETY: The captured `[MaybeUninit<u8>]` will all be part of the same allocation object, and borrowck
-// will assure that the borrows that occur on `self` on the relevant methods live long enough since they are
+// will ensure that the borrows that occur on `self` on the relevant methods live long enough since they are
 // native borrows anyway.
 unsafe impl Slab for [MaybeUninit<u8>] {
     fn base_ptr(&self) -> *const u8 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -538,7 +538,7 @@ pub(crate) struct ComputedOffsets {
 }
 
 /// Compute and validate offsets for a copy or read operation with the given parameters.
-pub(crate) fn compute_offsets<S: Slab>(
+pub(crate) fn compute_and_validate_offsets<S: Slab>(
     slab: &S,
     start_offset: usize,
     t_layout: Layout,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,7 @@
 //! `T: Copy` type which has *any padding bytes in its layout* as a `&[u8]` to be the source of a copy is
 //! **also instantly undefined behavior**, in both cases because it is *invalid* to create a reference to an invalid
 //! value (and uninitialized memory is an invalid `u8`), *even if* your code never actually accesses that memory.
-//! This immediately makes what seems like the most straightforward way to copy data into buffers unsound 😬.
+//! This immediately makes what seems like the most straightforward way to copy data into buffers unsound 😬
 //!
 //! `presser` helps with this by allowing you to view raw allocated memory of some size as a "[`Slab`]" of memory and then
 //! provides *safe, valid* ways to copy data into that memory. For example, you could implement [`Slab`] for your
@@ -24,10 +24,10 @@
 //! \* *If you're currently thinking to yourself "bah! what's the issue? surely an uninit u8 is just any random bit pattern
 //! and that's fine we don't care," [check out this blog post](https://www.ralfj.de/blog/2019/07/14/uninit.html) by
 //! @RalfJung, one of the people leading the effort to better define Rust's memory and execution model. As is explored
-//! in that blog post, an *uninit* piece of memory is not simply *an arbitrary bit pattern*, it is a wholly separate
+//! in that blog post, an* uninit *piece of memory is not simply* an arbitrary bit pattern, *it is a wholly separate
 //! state about a piece of memory, outside of its value, which lets the compiler perform optimizations that reorder,
 //! delete, and otherwise change the actual execution flow of your program in ways that cannot be described simply
-//! by "the value could have *some* possible bit pattern". LLVM and Clang are changing themselves to require special
+//! by "the value could have* some *possible bit pattern". LLVM and Clang are changing themselves to require special
 //! `noundef` attribute to perform many important optimizations that are otherwise unsound. For a concrete example
 //! of the sorts of problems this can cause,
 //! [see this issue @scottmcm hit](https://github.com/rust-lang/rust/pull/98919#issuecomment-1186106387).*

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -333,6 +333,9 @@ pub unsafe trait Slab {
     /// View a portion of `self` as a [`c_void`] pointer and size, appropriate for sending to an FFI function
     /// to be filled and then read using one or more of the `read_` helper functions.
     ///
+    /// You may want to use [`readback_from_ffi`] or [`readback_sice_from_ffi`] instead, which are
+    /// even less prone to misuse.
+    ///
     /// # Panics
     ///
     /// Panics if the range is out of bounds of `self`
@@ -605,7 +608,7 @@ pub(crate) struct ComputedOffsets {
 }
 
 /// Compute and validate offsets for a copy or read operation with the given parameters.
-#[inline]
+#[inline(always)]
 pub(crate) fn compute_and_validate_offsets<S: Slab>(
     slab: &S,
     start_offset: usize,

--- a/src/read.rs
+++ b/src/read.rs
@@ -1,0 +1,1 @@
+use super::*;

--- a/src/read.rs
+++ b/src/read.rs
@@ -80,7 +80,7 @@ pub unsafe fn read_at_offset_mut<'a, T, S: Slab>(slab: &'a mut S, offset: usize)
 /// Validity is a complex topic not to be taken lightly.
 /// See [this rust reference page](https://doc.rust-lang.org/reference/behavior-considered-undefined.html) for more details.
 #[inline]
-pub fn read_maybe_uninit_at_offset_mut<'a, T, S: Slab>(slab: &'a mut S, offset: usize) -> Result<&'a mut MaybeUninit<T>, Error> {
+pub fn get_maybe_uninit_at_offset_mut<'a, T, S: Slab>(slab: &'a mut S, offset: usize) -> Result<&'a mut MaybeUninit<T>, Error> {
     let t_layout = Layout::new::<T>();
     let offsets = compute_offsets(slab, offset, t_layout, 1, true)?;
 
@@ -184,7 +184,7 @@ pub unsafe fn read_slice_at_offset_mut<'a, T, S: Slab>(slab: &'a mut S, offset: 
 /// Validity is a complex topic not to be taken lightly.
 /// See [this rust reference page](https://doc.rust-lang.org/reference/behavior-considered-undefined.html) for more details.
 #[inline]
-pub fn read_maybe_uninit_slice_at_offset_mut<'a, T, S: Slab>(slab: &'a mut S, offset: usize, len: usize) -> Result<&'a mut [MaybeUninit<T>], Error> {
+pub fn get_maybe_uninit_slice_at_offset_mut<'a, T, S: Slab>(slab: &'a mut S, offset: usize, len: usize) -> Result<&'a mut [MaybeUninit<T>], Error> {
     let t_layout = match Layout::array::<T>(len) {
         Ok(layout) => layout,
         Err(_) => return Err(Error::InvalidLayout),

--- a/src/read.rs
+++ b/src/read.rs
@@ -1,16 +1,16 @@
 use super::*;
 
 /// Gets a shared reference to a `T` within `slab` at `offset`.
-/// 
+///
 /// - `offset` is the offset, in bytes, after the start of `slab` at which a `T` is placed.
-/// 
+///
 /// The function will return an error if:
 /// - `offset` within `slab` is not properly aligned for `T`
 /// - `offset` is out of bounds of the `slab`
 /// - `offset + size_of::<T>` is out of bounds of the `slab`
-/// 
+///
 /// # Safety
-/// 
+///
 /// You must have previously **fully-initialized** a **valid** `T` at the given offset into `slab`.
 /// Validity is a complex topic not to be taken lightly.
 /// See [this rust reference page](https://doc.rust-lang.org/reference/behavior-considered-undefined.html) for more details.
@@ -22,7 +22,7 @@ pub unsafe fn read_at_offset<'a, T, S: Slab>(slab: &'a S, offset: usize) -> Resu
     // SAFETY: if compute_offsets succeeded, this has already been checked to be safe.
     let ptr = unsafe { slab.base_ptr().add(offsets.start) }.cast::<T>();
 
-    // SAFETY: 
+    // SAFETY:
     // - `ptr` is properly aligned, checked by us
     // - `slab` contains enough space for `T` at `ptr`, checked by
     // - if the function-level safety guarantees are met, then:
@@ -32,30 +32,33 @@ pub unsafe fn read_at_offset<'a, T, S: Slab>(slab: &'a S, offset: usize) -> Resu
 }
 
 /// Gets a mutable reference to a `T` within `slab` at `offset`.
-/// 
+///
 /// - `offset` is the offset, in bytes, after the start of `slab` at which a `T` is placed.
-/// 
+///
 /// The function will return an error if:
 /// - `offset` within `slab` is not properly aligned for `T`
 /// - `offset` is out of bounds of the `slab`
 /// - `offset + size_of::<T>` is out of bounds of the `slab`
-/// 
+///
 /// # Safety
-/// 
+///
 /// You must have previously **fully-initialized** a **valid**\* `T` at the given offset into `slab`. If you want to fill an uninitialized
 /// buffer with data, you should instead use any of the copy helper functions or one of the `maybe_uninit_mut` read functions.
-/// 
+///
 /// \* Validity is a complex topic not to be taken lightly.
 /// See [this rust reference page](https://doc.rust-lang.org/reference/behavior-considered-undefined.html) for more details.
 #[inline]
-pub unsafe fn read_at_offset_mut<'a, T, S: Slab>(slab: &'a mut S, offset: usize) -> Result<&'a mut T, Error> {
+pub unsafe fn read_at_offset_mut<'a, T, S: Slab>(
+    slab: &'a mut S,
+    offset: usize,
+) -> Result<&'a mut T, Error> {
     let t_layout = Layout::new::<T>();
     let offsets = compute_and_validate_offsets(slab, offset, t_layout, 1, true)?;
 
     // SAFETY: if compute_offsets succeeded, this has already been checked to be safe.
     let ptr = unsafe { slab.base_ptr_mut().add(offsets.start) }.cast::<T>();
 
-    // SAFETY: 
+    // SAFETY:
     // - `ptr` is properly aligned, checked by us
     // - `slab` contains enough space for `T` at `ptr`, checked by
     // - if the function-level safety guarantees are met, then:
@@ -65,29 +68,32 @@ pub unsafe fn read_at_offset_mut<'a, T, S: Slab>(slab: &'a mut S, offset: usize)
 }
 
 /// Gets a mutable reference to a `MaybeUninit<T>` within `slab` at `offset`.
-/// 
+///
 /// - `offset` is the offset, in bytes, after the start of `slab` at which a `T` may be placed.
-/// 
+///
 /// The function will return an error if:
 /// - `offset` within `slab` is not properly aligned for `T`
 /// - `offset` is out of bounds of the `slab`
 /// - `offset + size_of::<T>` is out of bounds of the `slab`
-/// 
+///
 /// # Safety
-/// 
+///
 /// This function is safe since in order to read any data you need to call the unsafe [`MaybeUninit::assume_init`] on the returned value.
 /// However, you should know that if you do that, you must have ensured that there is indeed a **valid** `T` in its place.
 /// Validity is a complex topic not to be taken lightly.
 /// See [this rust reference page](https://doc.rust-lang.org/reference/behavior-considered-undefined.html) for more details.
 #[inline]
-pub fn get_maybe_uninit_at_offset_mut<'a, T, S: Slab>(slab: &'a mut S, offset: usize) -> Result<&'a mut MaybeUninit<T>, Error> {
+pub fn get_maybe_uninit_at_offset_mut<'a, T, S: Slab>(
+    slab: &'a mut S,
+    offset: usize,
+) -> Result<&'a mut MaybeUninit<T>, Error> {
     let t_layout = Layout::new::<T>();
     let offsets = compute_and_validate_offsets(slab, offset, t_layout, 1, true)?;
 
     // SAFETY: if compute_offsets succeeded, this has already been checked to be safe.
     let ptr = unsafe { slab.base_ptr_mut().add(offsets.start) }.cast::<MaybeUninit<T>>();
 
-    // SAFETY: 
+    // SAFETY:
     // - `ptr` is properly aligned, checked by us
     // - `slab` contains enough space for `T` at `ptr`, checked by us
     // - if the function-level safety guarantees are met, then:
@@ -96,22 +102,26 @@ pub fn get_maybe_uninit_at_offset_mut<'a, T, S: Slab>(slab: &'a mut S, offset: u
 }
 
 /// Reads a `&[T]` within `slab` at `offset`.
-/// 
+///
 /// - `offset` is the offset, in bytes, after the start of `slab` at which a `[T; len]` is placed.
 /// - `len` is the length of the returned slice, counted in elements of `T`.
-/// 
+///
 /// The function will return an error if:
 /// - `offset` within `slab` is not properly aligned for `T`
 /// - `offset` is out of bounds of the `slab`
 /// - `offset + size_of::<T> * len` is out of bounds of the `slab`
-/// 
+///
 /// # Safety
-/// 
+///
 /// You must have previously **fully-initialized** a **valid** a `[T; len]` at the given offset into `slab`.
 /// Validity is a complex topic not to be taken lightly.
 /// See [this rust reference page](https://doc.rust-lang.org/reference/behavior-considered-undefined.html) for more details.
 #[inline]
-pub unsafe fn read_slice_at_offset<'a, T, S: Slab>(slab: &'a S, offset: usize, len: usize) -> Result<&'a [T], Error> {
+pub unsafe fn read_slice_at_offset<'a, T, S: Slab>(
+    slab: &'a S,
+    offset: usize,
+    len: usize,
+) -> Result<&'a [T], Error> {
     let t_layout = match Layout::array::<T>(len) {
         Ok(layout) => layout,
         Err(_) => return Err(Error::InvalidLayout),
@@ -121,7 +131,7 @@ pub unsafe fn read_slice_at_offset<'a, T, S: Slab>(slab: &'a S, offset: usize, l
     // SAFETY: if compute_offsets succeeded, this has already been checked to be safe.
     let ptr = unsafe { slab.base_ptr().add(offsets.start) }.cast::<T>();
 
-    // SAFETY: 
+    // SAFETY:
     // - `ptr` is properly aligned, checked by us
     // - `slab` contains enough space for the slice's layout, checked by us
     // - if the function-level safety guarantees are met, then:
@@ -131,24 +141,28 @@ pub unsafe fn read_slice_at_offset<'a, T, S: Slab>(slab: &'a S, offset: usize, l
 }
 
 /// Reads a `&mut [T]` within `slab` at `offset`.
-/// 
+///
 /// - `offset` is the offset, in bytes, after the start of `slab` at which a `[T; len]` is placed.
 /// - `len` is the length of the returned slice, counted in elements of `T`.
-/// 
+///
 /// The function will return an error if:
 /// - `offset` within `slab` is not properly aligned for `T`
 /// - `offset` is out of bounds of the `slab`
 /// - `offset + size_of::<T> * len` is out of bounds of the `slab`
-/// 
+///
 /// # Safety
-/// 
+///
 /// You must have previously **fully-initialized** a **valid**\* `[T; len]` at the given offset into `slab`. If you want to fill an uninitialized
 /// buffer with data, you should instead use any of the copy helper functions or one of the `maybe_uninit_mut` read functions.
-/// 
+///
 /// \* Validity is a complex topic not to be taken lightly.
 /// See [this rust reference page](https://doc.rust-lang.org/reference/behavior-considered-undefined.html) for more details.
 #[inline]
-pub unsafe fn read_slice_at_offset_mut<'a, T, S: Slab>(slab: &'a mut S, offset: usize, len: usize) -> Result<&'a mut [T], Error> {
+pub unsafe fn read_slice_at_offset_mut<'a, T, S: Slab>(
+    slab: &'a mut S,
+    offset: usize,
+    len: usize,
+) -> Result<&'a mut [T], Error> {
     let t_layout = match Layout::array::<T>(len) {
         Ok(layout) => layout,
         Err(_) => return Err(Error::InvalidLayout),
@@ -158,7 +172,7 @@ pub unsafe fn read_slice_at_offset_mut<'a, T, S: Slab>(slab: &'a mut S, offset: 
     // SAFETY: if compute_offsets succeeded, this has already been checked to be safe.
     let ptr = unsafe { slab.base_ptr_mut().add(offsets.start) }.cast::<T>();
 
-    // SAFETY: 
+    // SAFETY:
     // - `ptr` is properly aligned, checked by us
     // - `slab` contains enough space for the slice's layout, checked by us
     // - if the function-level safety guarantees are met, then:
@@ -168,23 +182,27 @@ pub unsafe fn read_slice_at_offset_mut<'a, T, S: Slab>(slab: &'a mut S, offset: 
 }
 
 /// Gets a `&mut [MaybeUninit<T>]` within `slab` at `offset`.
-/// 
+///
 /// - `offset` is the offset, in bytes, after the start of `slab` at which a `[T; len]` may be placed.
 /// - `len` is the length of the returned slice, counted in elements of `T`.
-/// 
+///
 /// The function will return an error if:
 /// - `offset` within `slab` is not properly aligned for `T`
 /// - `offset` is out of bounds of the `slab`
 /// - `offset + size_of::<T> * len` is out of bounds of the `slab`
-/// 
+///
 /// # Safety
-/// 
+///
 /// This function is safe since in order to read any data you need to call the unsafe [`MaybeUninit::assume_init`] on the returned value.
 /// However, you should know that if you do that, you must have ensured that there is indeed a **valid** `T` in its place.
 /// Validity is a complex topic not to be taken lightly.
 /// See [this rust reference page](https://doc.rust-lang.org/reference/behavior-considered-undefined.html) for more details.
 #[inline]
-pub fn get_maybe_uninit_slice_at_offset_mut<'a, T, S: Slab>(slab: &'a mut S, offset: usize, len: usize) -> Result<&'a mut [MaybeUninit<T>], Error> {
+pub fn get_maybe_uninit_slice_at_offset_mut<'a, T, S: Slab>(
+    slab: &'a mut S,
+    offset: usize,
+    len: usize,
+) -> Result<&'a mut [MaybeUninit<T>], Error> {
     let t_layout = match Layout::array::<T>(len) {
         Ok(layout) => layout,
         Err(_) => return Err(Error::InvalidLayout),
@@ -194,7 +212,7 @@ pub fn get_maybe_uninit_slice_at_offset_mut<'a, T, S: Slab>(slab: &'a mut S, off
     // SAFETY: if compute_offsets succeeded, this has already been checked to be safe.
     let ptr = unsafe { slab.base_ptr_mut().add(offsets.start) }.cast::<MaybeUninit<T>>();
 
-    // SAFETY: 
+    // SAFETY:
     // - `ptr` is properly aligned, checked by us
     // - `slab` contains enough space for the slice's layout, checked by us
     // - if the function-level safety guarantees are met, then:

--- a/src/read.rs
+++ b/src/read.rs
@@ -46,7 +46,10 @@ where
 /// `slab` will be used as the backing data to write the slice of `T`s into. The `*mut c_void`
 /// pointer given to the function will be as close to the beginning of `slab` as possible while
 /// upholding the alignment requirements of `T`.
-pub unsafe fn readback_slice_from_ffi<'a, T, S, F>(slab: &'a mut S, fill_slab: F) -> Result<&'a [T], Error>
+pub unsafe fn readback_slice_from_ffi<'a, T, S, F>(
+    slab: &'a mut S,
+    fill_slab: F,
+) -> Result<&'a [T], Error>
 where
     S: Slab,
     F: FnOnce(*mut c_void, usize) -> usize,

--- a/src/read.rs
+++ b/src/read.rs
@@ -31,6 +31,35 @@ pub unsafe fn read_at_offset<'a, T, S: Slab>(slab: &'a S, offset: usize) -> Resu
     Ok(unsafe { &*ptr })
 }
 
+/// Gets a shared reference to a `T` within `slab` at `offset`, not checking any requirements.
+///
+/// - `offset` is the offset, in bytes, after the start of `slab` at which a `T` is placed.
+///
+/// # Safety
+///
+/// You must ensure:
+///
+/// - `offset` within `slab` is properly aligned for `T`
+/// - `offset` is within bounds of the `slab`
+/// - `offset + size_of::<T>` is within bounds of the `slab`
+/// - You must have previously **fully-initialized** a **valid** `T` at the given offset into `slab`.
+/// Validity is a complex topic not to be taken lightly.
+/// See [this rust reference page](https://doc.rust-lang.org/reference/behavior-considered-undefined.html) for more details.
+#[inline]
+pub unsafe fn read_at_offset_unchecked<'a, T, S: Slab>(slab: &'a S, offset: usize) -> &'a T {
+    // SAFETY: if offset is within the slab as guaranteed by function-level safety, this is
+    // safe since a slab's size must be < isize::MAX
+    let ptr = unsafe { slab.base_ptr().add(offset) }.cast::<T>();
+
+    // SAFETY:
+    // - we have shared access to all of `slab`, which includes `ptr`.
+    // - if the function-level safety guarantees are met, then:
+    //     - `ptr` is properly aligned
+    //     - `slab` contains enough space for `T` at `ptr`
+    //     - `ptr` contains a previously-placed `T`
+    unsafe { &*ptr }
+}
+
 /// Gets a mutable reference to a `T` within `slab` at `offset`.
 ///
 /// - `offset` is the offset, in bytes, after the start of `slab` at which a `T` is placed.
@@ -60,11 +89,45 @@ pub unsafe fn read_at_offset_mut<'a, T, S: Slab>(
 
     // SAFETY:
     // - `ptr` is properly aligned, checked by us
-    // - `slab` contains enough space for `T` at `ptr`, checked by
+    // - `slab` contains enough space for `T` at `ptr`, checked by us
+    // - we have unique access to all of `slab`, which includes `ptr`.
     // - if the function-level safety guarantees are met, then:
     //     - `ptr` contains a previously-placed `T`
-    //     - we have unique access to all of `slab`, which includes `ptr`.
     Ok(unsafe { &mut *ptr })
+}
+
+/// Gets a mutable reference to a `T` within `slab` at `offset`, not checking any requirements.
+///
+/// - `offset` is the offset, in bytes, after the start of `slab` at which a `T` is placed.
+///
+/// # Safety
+///
+/// You must ensure:
+///
+/// - `offset` within `slab` is properly aligned for `T`
+/// - `offset` is within bounds of the `slab`
+/// - `offset + size_of::<T>` is within bounds of the `slab`
+/// - You must have previously **fully-initialized** a **valid** `T` at the given offset into `slab`. If you want to fill an uninitialized
+/// buffer with data, you should instead use any of the copy helper functions or one of the `maybe_uninit_mut` read functions.
+///
+/// \* Validity is a complex topic not to be taken lightly.
+/// See [this rust reference page](https://doc.rust-lang.org/reference/behavior-considered-undefined.html) for more details.
+#[inline]
+pub unsafe fn read_at_offset_mut_unchecked<'a, T, S: Slab>(
+    slab: &'a mut S,
+    offset: usize,
+) -> &'a mut T {
+    // SAFETY: if offset is within the slab as guaranteed by function-level safety, this is
+    // safe since a slab's size must be < isize::MAX
+    let ptr = unsafe { slab.base_ptr_mut().add(offset) }.cast::<T>();
+
+    // SAFETY:
+    // - we have mutable access to all of `slab`, which includes `ptr`.
+    // - if the function-level safety guarantees are met, then:
+    //     - `ptr` is properly aligned
+    //     - `slab` contains enough space for `T` at `ptr`
+    //     - `ptr` contains a previously-placed `T`
+    unsafe { &mut *ptr }
 }
 
 /// Gets a mutable reference to a `MaybeUninit<T>` within `slab` at `offset`.
@@ -99,6 +162,38 @@ pub fn get_maybe_uninit_at_offset_mut<'a, T, S: Slab>(
     // - if the function-level safety guarantees are met, then:
     //     - we have unique access to all of `slab`, which includes `ptr`.
     Ok(unsafe { &mut *ptr })
+}
+
+/// Gets a mutable reference to a `MaybeUninit<T>` within `slab` at `offset`, not checking any requirements.
+///
+/// - `offset` is the offset, in bytes, after the start of `slab` at which a `T` is placed.
+///
+/// # Safety
+///
+/// You must ensure:
+///
+/// - `offset` within `slab` is properly aligned for `T`
+/// - `offset` is within bounds of the `slab`
+/// - `offset + size_of::<T>` is within bounds of the `slab`
+///
+/// You must have ensured there is a **fully-initialized** and **valid** `T` at the given offset into `slab` before calling [`MaybeUninit::assume_init`].
+/// Validity is a complex topic not to be taken lightly.
+/// See [this rust reference page](https://doc.rust-lang.org/reference/behavior-considered-undefined.html) for more details.
+#[inline]
+pub unsafe fn get_maybe_uninit_at_offset_mut_unchecked<'a, T, S: Slab>(
+    slab: &'a mut S,
+    offset: usize,
+) -> &'a mut MaybeUninit<T> {
+    // SAFETY: if offset is within the slab as guaranteed by function-level safety, this is
+    // safe since a slab's size must be < isize::MAX
+    let ptr = unsafe { slab.base_ptr_mut().add(offset) }.cast::<MaybeUninit<T>>();
+
+    // SAFETY:
+    // - we have mutable access to all of `slab`, which includes `ptr`.
+    // - if the function-level safety guarantees are met, then:
+    //     - `ptr` is properly aligned
+    //     - `slab` contains enough space for `T` at `ptr`
+    unsafe { &mut *ptr }
 }
 
 /// Reads a `&[T]` within `slab` at `offset`.
@@ -138,6 +233,41 @@ pub unsafe fn read_slice_at_offset<'a, T, S: Slab>(
     //     - `ptr` contains a previously-placed `[T; len]`
     //     - we have shared access to all of `slab`, which includes `ptr`.
     Ok(unsafe { core::slice::from_raw_parts(ptr, len) })
+}
+
+/// Reads a `&[T]` within `slab` at `offset`, not checking any requirements.
+///
+/// - `offset` is the offset, in bytes, after the start of `slab` at which a `[T; len]` is placed.
+/// - `len` is the length of the returned slice, counted in elements of `T`.
+///
+/// # Safety
+///
+/// You must ensure:
+///
+/// - `offset` within `slab` is properly aligned for `T`
+/// - `offset` is within bounds of the `slab`
+/// - `offset + size_of::<T> * len` is within bounds of the `slab`
+/// - You must have previously **fully-initialized** a **valid** a `[T; len]` at the given offset into `slab`.
+/// Validity is a complex topic not to be taken lightly.
+/// See [this rust reference page](https://doc.rust-lang.org/reference/behavior-considered-undefined.html) for more details.
+/// - See also safety docs of [`core::slice::from_raw_parts`].
+#[inline]
+pub unsafe fn read_slice_at_offset_unchecked<'a, T, S: Slab>(
+    slab: &'a S,
+    offset: usize,
+    len: usize,
+) -> &'a [T] {
+    // SAFETY: if offset is within the slab as guaranteed by function-level safety, this is
+    // safe since a slab's size must be < isize::MAX
+    let ptr = unsafe { slab.base_ptr().add(offset) }.cast::<T>();
+
+    // SAFETY:
+    // - we have shared access to all of `slab`, which includes `ptr`.
+    // - if the function-level safety guarantees are met, then:
+    //     - `ptr` is properly aligned, checked by us
+    //     - `slab` contains enough space for the slice's layout, checked by us
+    //     - `ptr` contains a previously-placed `[T; len]`
+    unsafe { core::slice::from_raw_parts(ptr, len) }
 }
 
 /// Reads a `&mut [T]` within `slab` at `offset`.
@@ -181,6 +311,43 @@ pub unsafe fn read_slice_at_offset_mut<'a, T, S: Slab>(
     Ok(unsafe { core::slice::from_raw_parts_mut(ptr, len) })
 }
 
+/// Reads a `&mut [T]` within `slab` at `offset`, not checking any requirements.
+///
+/// - `offset` is the offset, in bytes, after the start of `slab` at which a `[T; len]` is placed.
+/// - `len` is the length of the returned slice, counted in elements of `T`.
+///
+/// # Safety
+///
+/// You must ensure:
+///
+/// - `offset` within `slab` is properly aligned for `T`
+/// - `offset` is within bounds of the `slab`
+/// - `offset + size_of::<T> * len` is within bounds of the `slab`
+/// - You must have previously **fully-initialized** a **valid** a `[T; len]` at the given offset into `slab`. If you want to fill an uninitialized
+/// buffer with data, you should instead use any of the copy helper functions or one of the `maybe_uninit_mut` read functions.
+/// - See also safety docs of [`core::slice::from_raw_parts_mut`].
+///
+/// \* Validity is a complex topic not to be taken lightly.
+/// See [this rust reference page](https://doc.rust-lang.org/reference/behavior-considered-undefined.html) for more details.
+#[inline]
+pub unsafe fn read_slice_at_offset_mut_unchecked<'a, T, S: Slab>(
+    slab: &'a mut S,
+    offset: usize,
+    len: usize,
+) -> &'a mut [T] {
+    // SAFETY: if offset is within the slab as guaranteed by function-level safety, this is
+    // safe since a slab's size must be < isize::MAX
+    let ptr = unsafe { slab.base_ptr_mut().add(offset) }.cast::<T>();
+
+    // SAFETY:
+    // - we have shared access to all of `slab`, which includes `ptr`.
+    // - if the function-level safety guarantees are met, then:
+    //     - `ptr` is properly aligned, checked by us
+    //     - `slab` contains enough space for the slice's layout, checked by us
+    //     - `ptr` contains a previously-placed `[T; len]`
+    unsafe { core::slice::from_raw_parts_mut(ptr, len) }
+}
+
 /// Gets a `&mut [MaybeUninit<T>]` within `slab` at `offset`.
 ///
 /// - `offset` is the offset, in bytes, after the start of `slab` at which a `[T; len]` may be placed.
@@ -218,4 +385,39 @@ pub fn get_maybe_uninit_slice_at_offset_mut<'a, T, S: Slab>(
     // - if the function-level safety guarantees are met, then:
     //     - we have mutable access to all of `slab`, which includes `ptr`.
     Ok(unsafe { core::slice::from_raw_parts_mut(ptr, len) })
+}
+
+/// Gets a `&mut [MaybeUninit<T>]` within `slab` at `offset`, not checking any requirements.
+///
+/// - `offset` is the offset, in bytes, after the start of `slab` at which a `[T; len]` is placed.
+/// - `len` is the length of the returned slice, counted in elements of `T`.
+///
+/// # Safety
+///
+/// You must ensure:
+///
+/// - `offset` within `slab` is properly aligned for `T`
+/// - `offset` is within bounds of the `slab`
+/// - `offset + size_of::<T> * len` is within bounds of the `slab`
+/// - See also safety docs of [`core::slice::from_raw_parts_mut`].
+///
+/// You must have ensured there is a **fully-initialized** and **valid** `T` in each returned `MaybeUninit<T>` before calling [`MaybeUninit::assume_init`].
+/// Validity is a complex topic not to be taken lightly.
+/// See [this rust reference page](https://doc.rust-lang.org/reference/behavior-considered-undefined.html) for more details.
+#[inline]
+pub unsafe fn get_maybe_uninit_slice_at_offset_mut_unchecked<'a, T, S: Slab>(
+    slab: &'a mut S,
+    offset: usize,
+    len: usize,
+) -> &'a mut [MaybeUninit<T>] {
+    // SAFETY: if offset is within the slab as guaranteed by function-level safety, this is
+    // safe since a slab's size must be < isize::MAX
+    let ptr = unsafe { slab.base_ptr_mut().add(offset) }.cast::<MaybeUninit<T>>();
+
+    // SAFETY:
+    // - we have shared access to all of `slab`, which includes `ptr`.
+    // - if the function-level safety guarantees are met, then:
+    //     - `ptr` is properly aligned, checked by us
+    //     - `slab` contains enough space for the slice's layout, checked by us
+    unsafe { core::slice::from_raw_parts_mut(ptr, len) }
 }

--- a/src/read.rs
+++ b/src/read.rs
@@ -17,7 +17,7 @@ use super::*;
 #[inline]
 pub unsafe fn read_at_offset<'a, T, S: Slab>(slab: &'a S, offset: usize) -> Result<&'a T, Error> {
     let t_layout = Layout::new::<T>();
-    let offsets = compute_offsets(slab, offset, t_layout, 1, true)?;
+    let offsets = compute_and_validate_offsets(slab, offset, t_layout, 1, true)?;
 
     // SAFETY: if compute_offsets succeeded, this has already been checked to be safe.
     let ptr = unsafe { slab.base_ptr().add(offsets.start) }.cast::<T>();
@@ -50,7 +50,7 @@ pub unsafe fn read_at_offset<'a, T, S: Slab>(slab: &'a S, offset: usize) -> Resu
 #[inline]
 pub unsafe fn read_at_offset_mut<'a, T, S: Slab>(slab: &'a mut S, offset: usize) -> Result<&'a mut T, Error> {
     let t_layout = Layout::new::<T>();
-    let offsets = compute_offsets(slab, offset, t_layout, 1, true)?;
+    let offsets = compute_and_validate_offsets(slab, offset, t_layout, 1, true)?;
 
     // SAFETY: if compute_offsets succeeded, this has already been checked to be safe.
     let ptr = unsafe { slab.base_ptr_mut().add(offsets.start) }.cast::<T>();
@@ -82,7 +82,7 @@ pub unsafe fn read_at_offset_mut<'a, T, S: Slab>(slab: &'a mut S, offset: usize)
 #[inline]
 pub fn get_maybe_uninit_at_offset_mut<'a, T, S: Slab>(slab: &'a mut S, offset: usize) -> Result<&'a mut MaybeUninit<T>, Error> {
     let t_layout = Layout::new::<T>();
-    let offsets = compute_offsets(slab, offset, t_layout, 1, true)?;
+    let offsets = compute_and_validate_offsets(slab, offset, t_layout, 1, true)?;
 
     // SAFETY: if compute_offsets succeeded, this has already been checked to be safe.
     let ptr = unsafe { slab.base_ptr_mut().add(offsets.start) }.cast::<MaybeUninit<T>>();
@@ -116,7 +116,7 @@ pub unsafe fn read_slice_at_offset<'a, T, S: Slab>(slab: &'a S, offset: usize, l
         Ok(layout) => layout,
         Err(_) => return Err(Error::InvalidLayout),
     };
-    let offsets = compute_offsets(slab, offset, t_layout, 1, true)?;
+    let offsets = compute_and_validate_offsets(slab, offset, t_layout, 1, true)?;
 
     // SAFETY: if compute_offsets succeeded, this has already been checked to be safe.
     let ptr = unsafe { slab.base_ptr().add(offsets.start) }.cast::<T>();
@@ -153,7 +153,7 @@ pub unsafe fn read_slice_at_offset_mut<'a, T, S: Slab>(slab: &'a mut S, offset: 
         Ok(layout) => layout,
         Err(_) => return Err(Error::InvalidLayout),
     };
-    let offsets = compute_offsets(slab, offset, t_layout, 1, true)?;
+    let offsets = compute_and_validate_offsets(slab, offset, t_layout, 1, true)?;
 
     // SAFETY: if compute_offsets succeeded, this has already been checked to be safe.
     let ptr = unsafe { slab.base_ptr_mut().add(offsets.start) }.cast::<T>();
@@ -189,7 +189,7 @@ pub fn get_maybe_uninit_slice_at_offset_mut<'a, T, S: Slab>(slab: &'a mut S, off
         Ok(layout) => layout,
         Err(_) => return Err(Error::InvalidLayout),
     };
-    let offsets = compute_offsets(slab, offset, t_layout, 1, true)?;
+    let offsets = compute_and_validate_offsets(slab, offset, t_layout, 1, true)?;
 
     // SAFETY: if compute_offsets succeeded, this has already been checked to be safe.
     let ptr = unsafe { slab.base_ptr_mut().add(offsets.start) }.cast::<MaybeUninit<T>>();

--- a/src/read.rs
+++ b/src/read.rs
@@ -12,6 +12,14 @@ use super::*;
 /// to the function will be as close to the beginning of `slab` as possible while upholding the
 /// alignment requirements of `T`. If a `T` cannot fit into `slab` while upholding those alignment
 /// requirements and the size of `T`, an error will be returned and `fill_slab` will not be called.
+///
+/// # Safety
+///
+/// You must during the execution of `fill_slab` **fully-initialize** a **valid**\* `T`
+/// at the given pointer.
+///
+/// \* Validity is a complex topic not to be taken lightly.
+/// See [this rust reference page](https://doc.rust-lang.org/reference/behavior-considered-undefined.html) for more details.
 pub unsafe fn readback_from_ffi<'a, T, S, F>(slab: &'a mut S, fill_slab: F) -> Result<&'a T, Error>
 where
     S: Slab,
@@ -46,6 +54,15 @@ where
 /// `slab` will be used as the backing data to write the slice of `T`s into. The `*mut c_void`
 /// pointer given to the function will be as close to the beginning of `slab` as possible while
 /// upholding the alignment requirements of `T`.
+///
+/// # Safety
+///
+/// You must during the execution of `fill_slab` **fully-initialize** a **valid**\* slice of `T`
+/// beginning at the given pointer and with length greater than or equal to the length you return
+/// from that function.
+///
+/// \* Validity is a complex topic not to be taken lightly.
+/// See [this rust reference page](https://doc.rust-lang.org/reference/behavior-considered-undefined.html) for more details.
 pub unsafe fn readback_slice_from_ffi<'a, T, S, F>(
     slab: &'a mut S,
     fill_slab: F,
@@ -78,6 +95,7 @@ where
     //     - we have mutable access to all of `slab`, which includes `ptr`.
     Ok(unsafe { core::slice::from_raw_parts(ptr, written_n_of_ts) })
 }
+
 /// Gets a shared reference to a `T` within `slab` at `offset`.
 ///
 /// - `offset` is the offset, in bytes, after the start of `slab` at which a `T` is placed.
@@ -89,8 +107,9 @@ where
 ///
 /// # Safety
 ///
-/// You must have previously **fully-initialized** a **valid** `T` at the given offset into `slab`.
-/// Validity is a complex topic not to be taken lightly.
+/// You must have previously **fully-initialized** a **valid**\* `T` at the given offset into `slab`.
+///
+/// \* Validity is a complex topic not to be taken lightly.
 /// See [this rust reference page](https://doc.rust-lang.org/reference/behavior-considered-undefined.html) for more details.
 #[inline]
 pub unsafe fn read_at_offset<'a, T, S: Slab>(slab: &'a S, offset: usize) -> Result<&'a T, Error> {

--- a/src/read.rs
+++ b/src/read.rs
@@ -1,1 +1,203 @@
 use super::*;
+
+/// Gets a shared reference to a `T` within `slab` at `offset`.
+/// 
+/// - `offset` is the offset, in bytes, after the start of `slab` at which a `T` is placed.
+/// 
+/// The function will return an error if:
+/// - `offset` within `slab` is not properly aligned for `T`
+/// - `offset` is out of bounds of the `slab`
+/// - `offset + size_of::<T>` is out of bounds of the `slab`
+/// 
+/// # Safety
+/// 
+/// You must have previously **fully-initialized** a **valid** `T` at the given offset into `slab`.
+/// Validity is a complex topic not to be taken lightly.
+/// See [this rust reference page](https://doc.rust-lang.org/reference/behavior-considered-undefined.html) for more details.
+#[inline]
+pub unsafe fn read_at_offset<'a, T, S: Slab>(slab: &'a S, offset: usize) -> Result<&'a T, Error> {
+    let t_layout = Layout::new::<T>();
+    let offsets = compute_offsets(slab, offset, t_layout, 1, true)?;
+
+    // SAFETY: if compute_offsets succeeded, this has already been checked to be safe.
+    let ptr = unsafe { slab.base_ptr().add(offsets.start) }.cast::<T>();
+
+    // SAFETY: 
+    // - `ptr` is properly aligned, checked by us
+    // - `slab` contains enough space for `T` at `ptr`, checked by
+    // - if the function-level safety guarantees are met, then:
+    //     - `ptr` contains a previously-placed `T`
+    //     - we have shared access to all of `slab`, which includes `ptr`.
+    Ok(unsafe { &*ptr })
+}
+
+/// Gets a mutable reference to a `T` within `slab` at `offset`.
+/// 
+/// - `offset` is the offset, in bytes, after the start of `slab` at which a `T` is placed.
+/// 
+/// The function will return an error if:
+/// - `offset` within `slab` is not properly aligned for `T`
+/// - `offset` is out of bounds of the `slab`
+/// - `offset + size_of::<T>` is out of bounds of the `slab`
+/// 
+/// # Safety
+/// 
+/// You must have previously **fully-initialized** a **valid**\* `T` at the given offset into `slab`. If you want to fill an uninitialized
+/// buffer with data, you should instead use any of the copy helper functions or one of the `maybe_uninit_mut` read functions.
+/// 
+/// \* Validity is a complex topic not to be taken lightly.
+/// See [this rust reference page](https://doc.rust-lang.org/reference/behavior-considered-undefined.html) for more details.
+#[inline]
+pub unsafe fn read_at_offset_mut<'a, T, S: Slab>(slab: &'a mut S, offset: usize) -> Result<&'a mut T, Error> {
+    let t_layout = Layout::new::<T>();
+    let offsets = compute_offsets(slab, offset, t_layout, 1, true)?;
+
+    // SAFETY: if compute_offsets succeeded, this has already been checked to be safe.
+    let ptr = unsafe { slab.base_ptr_mut().add(offsets.start) }.cast::<T>();
+
+    // SAFETY: 
+    // - `ptr` is properly aligned, checked by us
+    // - `slab` contains enough space for `T` at `ptr`, checked by
+    // - if the function-level safety guarantees are met, then:
+    //     - `ptr` contains a previously-placed `T`
+    //     - we have unique access to all of `slab`, which includes `ptr`.
+    Ok(unsafe { &mut *ptr })
+}
+
+/// Gets a mutable reference to a `MaybeUninit<T>` within `slab` at `offset`.
+/// 
+/// - `offset` is the offset, in bytes, after the start of `slab` at which a `T` may be placed.
+/// 
+/// The function will return an error if:
+/// - `offset` within `slab` is not properly aligned for `T`
+/// - `offset` is out of bounds of the `slab`
+/// - `offset + size_of::<T>` is out of bounds of the `slab`
+/// 
+/// # Safety
+/// 
+/// This function is safe since in order to read any data you need to call the unsafe [`MaybeUninit::assume_init`] on the returned value.
+/// However, you should know that if you do that, you must have ensured that there is indeed a **valid** `T` in its place.
+/// Validity is a complex topic not to be taken lightly.
+/// See [this rust reference page](https://doc.rust-lang.org/reference/behavior-considered-undefined.html) for more details.
+#[inline]
+pub fn read_maybe_uninit_at_offset_mut<'a, T, S: Slab>(slab: &'a mut S, offset: usize) -> Result<&'a mut MaybeUninit<T>, Error> {
+    let t_layout = Layout::new::<T>();
+    let offsets = compute_offsets(slab, offset, t_layout, 1, true)?;
+
+    // SAFETY: if compute_offsets succeeded, this has already been checked to be safe.
+    let ptr = unsafe { slab.base_ptr_mut().add(offsets.start) }.cast::<MaybeUninit<T>>();
+
+    // SAFETY: 
+    // - `ptr` is properly aligned, checked by us
+    // - `slab` contains enough space for `T` at `ptr`, checked by us
+    // - if the function-level safety guarantees are met, then:
+    //     - we have unique access to all of `slab`, which includes `ptr`.
+    Ok(unsafe { &mut *ptr })
+}
+
+/// Reads a `&[T]` within `slab` at `offset`.
+/// 
+/// - `offset` is the offset, in bytes, after the start of `slab` at which a `[T; len]` is placed.
+/// - `len` is the length of the returned slice, counted in elements of `T`.
+/// 
+/// The function will return an error if:
+/// - `offset` within `slab` is not properly aligned for `T`
+/// - `offset` is out of bounds of the `slab`
+/// - `offset + size_of::<T> * len` is out of bounds of the `slab`
+/// 
+/// # Safety
+/// 
+/// You must have previously **fully-initialized** a **valid** a `[T; len]` at the given offset into `slab`.
+/// Validity is a complex topic not to be taken lightly.
+/// See [this rust reference page](https://doc.rust-lang.org/reference/behavior-considered-undefined.html) for more details.
+#[inline]
+pub unsafe fn read_slice_at_offset<'a, T, S: Slab>(slab: &'a S, offset: usize, len: usize) -> Result<&'a [T], Error> {
+    let t_layout = match Layout::array::<T>(len) {
+        Ok(layout) => layout,
+        Err(_) => return Err(Error::InvalidLayout),
+    };
+    let offsets = compute_offsets(slab, offset, t_layout, 1, true)?;
+
+    // SAFETY: if compute_offsets succeeded, this has already been checked to be safe.
+    let ptr = unsafe { slab.base_ptr().add(offsets.start) }.cast::<T>();
+
+    // SAFETY: 
+    // - `ptr` is properly aligned, checked by us
+    // - `slab` contains enough space for the slice's layout, checked by us
+    // - if the function-level safety guarantees are met, then:
+    //     - `ptr` contains a previously-placed `[T; len]`
+    //     - we have shared access to all of `slab`, which includes `ptr`.
+    Ok(unsafe { core::slice::from_raw_parts(ptr, len) })
+}
+
+/// Reads a `&mut [T]` within `slab` at `offset`.
+/// 
+/// - `offset` is the offset, in bytes, after the start of `slab` at which a `[T; len]` is placed.
+/// - `len` is the length of the returned slice, counted in elements of `T`.
+/// 
+/// The function will return an error if:
+/// - `offset` within `slab` is not properly aligned for `T`
+/// - `offset` is out of bounds of the `slab`
+/// - `offset + size_of::<T> * len` is out of bounds of the `slab`
+/// 
+/// # Safety
+/// 
+/// You must have previously **fully-initialized** a **valid**\* `[T; len]` at the given offset into `slab`. If you want to fill an uninitialized
+/// buffer with data, you should instead use any of the copy helper functions or one of the `maybe_uninit_mut` read functions.
+/// 
+/// \* Validity is a complex topic not to be taken lightly.
+/// See [this rust reference page](https://doc.rust-lang.org/reference/behavior-considered-undefined.html) for more details.
+#[inline]
+pub unsafe fn read_slice_at_offset_mut<'a, T, S: Slab>(slab: &'a mut S, offset: usize, len: usize) -> Result<&'a mut [T], Error> {
+    let t_layout = match Layout::array::<T>(len) {
+        Ok(layout) => layout,
+        Err(_) => return Err(Error::InvalidLayout),
+    };
+    let offsets = compute_offsets(slab, offset, t_layout, 1, true)?;
+
+    // SAFETY: if compute_offsets succeeded, this has already been checked to be safe.
+    let ptr = unsafe { slab.base_ptr_mut().add(offsets.start) }.cast::<T>();
+
+    // SAFETY: 
+    // - `ptr` is properly aligned, checked by us
+    // - `slab` contains enough space for the slice's layout, checked by us
+    // - if the function-level safety guarantees are met, then:
+    //     - `ptr` contains a previously-placed `[T; len]`
+    //     - we have mutable access to all of `slab`, which includes `ptr`.
+    Ok(unsafe { core::slice::from_raw_parts_mut(ptr, len) })
+}
+
+/// Gets a `&mut [MaybeUninit<T>]` within `slab` at `offset`.
+/// 
+/// - `offset` is the offset, in bytes, after the start of `slab` at which a `[T; len]` may be placed.
+/// - `len` is the length of the returned slice, counted in elements of `T`.
+/// 
+/// The function will return an error if:
+/// - `offset` within `slab` is not properly aligned for `T`
+/// - `offset` is out of bounds of the `slab`
+/// - `offset + size_of::<T> * len` is out of bounds of the `slab`
+/// 
+/// # Safety
+/// 
+/// This function is safe since in order to read any data you need to call the unsafe [`MaybeUninit::assume_init`] on the returned value.
+/// However, you should know that if you do that, you must have ensured that there is indeed a **valid** `T` in its place.
+/// Validity is a complex topic not to be taken lightly.
+/// See [this rust reference page](https://doc.rust-lang.org/reference/behavior-considered-undefined.html) for more details.
+#[inline]
+pub fn read_maybe_uninit_slice_at_offset_mut<'a, T, S: Slab>(slab: &'a mut S, offset: usize, len: usize) -> Result<&'a mut [MaybeUninit<T>], Error> {
+    let t_layout = match Layout::array::<T>(len) {
+        Ok(layout) => layout,
+        Err(_) => return Err(Error::InvalidLayout),
+    };
+    let offsets = compute_offsets(slab, offset, t_layout, 1, true)?;
+
+    // SAFETY: if compute_offsets succeeded, this has already been checked to be safe.
+    let ptr = unsafe { slab.base_ptr_mut().add(offsets.start) }.cast::<MaybeUninit<T>>();
+
+    // SAFETY: 
+    // - `ptr` is properly aligned, checked by us
+    // - `slab` contains enough space for the slice's layout, checked by us
+    // - if the function-level safety guarantees are met, then:
+    //     - we have mutable access to all of `slab`, which includes `ptr`.
+    Ok(unsafe { core::slice::from_raw_parts_mut(ptr, len) })
+}

--- a/src/read.rs
+++ b/src/read.rs
@@ -44,8 +44,9 @@ pub unsafe fn read_at_offset<'a, T, S: Slab>(slab: &'a S, offset: usize) -> Resu
 /// - `offset` within `slab` is properly aligned for `T`
 /// - `offset` is within bounds of the `slab`
 /// - `offset + size_of::<T>` is within bounds of the `slab`
-/// - You must have previously **fully-initialized** a **valid** `T` at the given offset into `slab`.
-/// Validity is a complex topic not to be taken lightly.
+/// - You must have previously **fully-initialized** a **valid**\* `T` at the given offset into `slab`.
+///
+/// \* Validity is a complex topic not to be taken lightly.
 /// See [this rust reference page](https://doc.rust-lang.org/reference/behavior-considered-undefined.html) for more details.
 #[inline]
 pub unsafe fn read_at_offset_unchecked<'a, T, S: Slab>(slab: &'a S, offset: usize) -> &'a T {
@@ -75,6 +76,13 @@ pub unsafe fn read_at_offset_unchecked<'a, T, S: Slab>(slab: &'a S, offset: usiz
 ///
 /// You must have previously **fully-initialized** a **valid**\* `T` at the given offset into `slab`. If you want to fill an uninitialized
 /// buffer with data, you should instead use any of the copy helper functions or one of the `maybe_uninit_mut` read functions.
+///
+/// **Note that *if you write through the returned reference***, any *padding bytes* within the layout of `T`
+/// (which for a `repr(Rust)` type is arbitrary and unknown) must thereafter be considered *uninitialized*
+/// until you explicitly initialize them again. This means that if you write a `T` which contains
+/// padding into `slab`, you **must not**, for example, try to read those bytes as `&[u8]` afterwards
+/// (or as some other type which expects those bytes to be initialized), as you would then be
+/// reading uninitialized memory, which is *undefined behavior*.
 ///
 /// \* Validity is a complex topic not to be taken lightly.
 /// See [this rust reference page](https://doc.rust-lang.org/reference/behavior-considered-undefined.html) for more details.
@@ -112,6 +120,13 @@ pub unsafe fn read_at_offset_mut<'a, T, S: Slab>(
 /// - You must have previously **fully-initialized** a **valid** `T` at the given offset into `slab`. If you want to fill an uninitialized
 /// buffer with data, you should instead use any of the copy helper functions or one of the `maybe_uninit_mut` read functions.
 ///
+/// **Note that *if you write through the returned reference***, any *padding bytes* within the layout of `T`
+/// (which for a `repr(Rust)` type is arbitrary and unknown) must thereafter be considered *uninitialized*
+/// until you explicitly initialize them again. This means that if you write a `T` which contains
+/// padding into `slab`, you **must not**, for example, try to read those bytes as `&[u8]` afterwards
+/// (or as some other type which expects those bytes to be initialized), as you would then be
+/// reading uninitialized memory, which is *undefined behavior*.
+///
 /// \* Validity is a complex topic not to be taken lightly.
 /// See [this rust reference page](https://doc.rust-lang.org/reference/behavior-considered-undefined.html) for more details.
 #[inline]
@@ -144,8 +159,16 @@ pub unsafe fn read_at_offset_mut_unchecked<'a, T, S: Slab>(
 /// # Safety
 ///
 /// This function is safe since in order to read any data you need to call the unsafe [`MaybeUninit::assume_init`] on the returned value.
-/// However, you should know that if you do that, you must have ensured that there is indeed a **valid** `T` in its place.
-/// Validity is a complex topic not to be taken lightly.
+/// However, you should know that if you do that, you must have ensured that there is indeed a **valid**\* `T` in its place.
+///
+/// **Note that *if you write through the returned reference***, any *padding bytes* within the layout of `T`
+/// (which for a `repr(Rust)` type is arbitrary and unknown) must thereafter be considered *uninitialized*
+/// until you explicitly initialize them again. This means that if you write a `T` which contains
+/// padding into `slab`, you **must not**, for example, try to read those bytes as `&[u8]` afterwards
+/// (or as some other type which expects those bytes to be initialized), as you would then be
+/// reading uninitialized memory, which is *undefined behavior*.
+///
+/// \* Validity is a complex topic not to be taken lightly.
 /// See [this rust reference page](https://doc.rust-lang.org/reference/behavior-considered-undefined.html) for more details.
 #[inline]
 pub fn get_maybe_uninit_at_offset_mut<'a, T, S: Slab>(
@@ -178,8 +201,16 @@ pub fn get_maybe_uninit_at_offset_mut<'a, T, S: Slab>(
 /// - `offset` is within bounds of the `slab`
 /// - `offset + size_of::<T>` is within bounds of the `slab`
 ///
-/// You must have ensured there is a **fully-initialized** and **valid** `T` at the given offset into `slab` before calling [`MaybeUninit::assume_init`].
-/// Validity is a complex topic not to be taken lightly.
+/// You must have ensured there is a **fully-initialized** and **valid**\* `T` at the given offset into `slab` before calling [`MaybeUninit::assume_init`].
+///
+/// **Note that *if you write through the returned reference***, any *padding bytes* within the layout of `T`
+/// (which for a `repr(Rust)` type is arbitrary and unknown) must thereafter be considered *uninitialized*
+/// until you explicitly initialize them again. This means that if you write a `T` which contains
+/// padding into `slab`, you **must not**, for example, try to read those bytes as `&[u8]` afterwards
+/// (or as some other type which expects those bytes to be initialized), as you would then be
+/// reading uninitialized memory, which is *undefined behavior*.
+///
+/// \* Validity is a complex topic not to be taken lightly.
 /// See [this rust reference page](https://doc.rust-lang.org/reference/behavior-considered-undefined.html) for more details.
 #[inline]
 pub unsafe fn get_maybe_uninit_at_offset_mut_unchecked<'a, T, S: Slab>(
@@ -210,8 +241,9 @@ pub unsafe fn get_maybe_uninit_at_offset_mut_unchecked<'a, T, S: Slab>(
 ///
 /// # Safety
 ///
-/// You must have previously **fully-initialized** a **valid** a `[T; len]` at the given offset into `slab`.
-/// Validity is a complex topic not to be taken lightly.
+/// You must have previously **fully-initialized** a **valid**\* a `[T; len]` at the given offset into `slab`.
+///
+/// \* Validity is a complex topic not to be taken lightly.
 /// See [this rust reference page](https://doc.rust-lang.org/reference/behavior-considered-undefined.html) for more details.
 #[inline]
 pub unsafe fn read_slice_at_offset<'a, T, S: Slab>(
@@ -249,8 +281,9 @@ pub unsafe fn read_slice_at_offset<'a, T, S: Slab>(
 /// - `offset` within `slab` is properly aligned for `T`
 /// - `offset` is within bounds of the `slab`
 /// - `offset + size_of::<T> * len` is within bounds of the `slab`
-/// - You must have previously **fully-initialized** a **valid** a `[T; len]` at the given offset into `slab`.
-/// Validity is a complex topic not to be taken lightly.
+/// - You must have previously **fully-initialized** a **valid**\* a `[T; len]` at the given offset into `slab`.
+///
+/// \* Validity is a complex topic not to be taken lightly.
 /// See [this rust reference page](https://doc.rust-lang.org/reference/behavior-considered-undefined.html) for more details.
 /// - See also safety docs of [`core::slice::from_raw_parts`].
 #[inline]
@@ -286,6 +319,13 @@ pub unsafe fn read_slice_at_offset_unchecked<'a, T, S: Slab>(
 ///
 /// You must have previously **fully-initialized** a **valid**\* `[T; len]` at the given offset into `slab`. If you want to fill an uninitialized
 /// buffer with data, you should instead use any of the copy helper functions or one of the `maybe_uninit_mut` read functions.
+///
+/// **Note that *if you write through the returned reference***, any *padding bytes* within the layout of `T`
+/// (which for a `repr(Rust)` type is arbitrary and unknown) must thereafter be considered *uninitialized*
+/// until you explicitly initialize them again. This means that if you write a `T` which contains
+/// padding into `slab`, you **must not**, for example, try to read those bytes as `&[u8]` afterwards
+/// (or as some other type which expects those bytes to be initialized), as you would then be
+/// reading uninitialized memory, which is *undefined behavior*.
 ///
 /// \* Validity is a complex topic not to be taken lightly.
 /// See [this rust reference page](https://doc.rust-lang.org/reference/behavior-considered-undefined.html) for more details.
@@ -329,6 +369,13 @@ pub unsafe fn read_slice_at_offset_mut<'a, T, S: Slab>(
 /// buffer with data, you should instead use any of the copy helper functions or one of the `maybe_uninit_mut` read functions.
 /// - See also safety docs of [`core::slice::from_raw_parts_mut`].
 ///
+/// **Note that *if you write through the returned reference***, any *padding bytes* within the layout of `T`
+/// (which for a `repr(Rust)` type is arbitrary and unknown) must thereafter be considered *uninitialized*
+/// until you explicitly initialize them again. This means that if you write a `T` which contains
+/// padding into `slab`, you **must not**, for example, try to read those bytes as `&[u8]` afterwards
+/// (or as some other type which expects those bytes to be initialized), as you would then be
+/// reading uninitialized memory, which is *undefined behavior*.
+///
 /// \* Validity is a complex topic not to be taken lightly.
 /// See [this rust reference page](https://doc.rust-lang.org/reference/behavior-considered-undefined.html) for more details.
 #[inline]
@@ -363,8 +410,16 @@ pub unsafe fn read_slice_at_offset_mut_unchecked<'a, T, S: Slab>(
 /// # Safety
 ///
 /// This function is safe since in order to read any data you need to call the unsafe [`MaybeUninit::assume_init`] on the returned value.
-/// However, you should know that if you do that, you must have ensured that there is indeed a **valid** `T` in its place.
-/// Validity is a complex topic not to be taken lightly.
+/// However, you should know that if you do that, you must have ensured that there is indeed a **valid**\* `T` in its place.
+///
+/// **Note that *if you write through the returned reference***, any *padding bytes* within the layout of `T`
+/// (which for a `repr(Rust)` type is arbitrary and unknown) must thereafter be considered *uninitialized*
+/// until you explicitly initialize them again. This means that if you write a `T` which contains
+/// padding into `slab`, you **must not**, for example, try to read those bytes as `&[u8]` afterwards
+/// (or as some other type which expects those bytes to be initialized), as you would then be
+/// reading uninitialized memory, which is *undefined behavior*.
+///
+/// \* Validity is a complex topic not to be taken lightly.
 /// See [this rust reference page](https://doc.rust-lang.org/reference/behavior-considered-undefined.html) for more details.
 #[inline]
 pub fn get_maybe_uninit_slice_at_offset_mut<'a, T, S: Slab>(
@@ -403,8 +458,16 @@ pub fn get_maybe_uninit_slice_at_offset_mut<'a, T, S: Slab>(
 /// - `offset + size_of::<T> * len` is within bounds of the `slab`
 /// - See also safety docs of [`core::slice::from_raw_parts_mut`].
 ///
-/// You must have ensured there is a **fully-initialized** and **valid** `T` in each returned `MaybeUninit<T>` before calling [`MaybeUninit::assume_init`].
-/// Validity is a complex topic not to be taken lightly.
+/// You must have ensured there is a **fully-initialized** and **valid**\* `T` in each returned `MaybeUninit<T>` before calling [`MaybeUninit::assume_init`].
+///
+/// **Note that *if you write through the returned reference***, any *padding bytes* within the layout of `T`
+/// (which for a `repr(Rust)` type is arbitrary and unknown) must thereafter be considered *uninitialized*
+/// until you explicitly initialize them again. This means that if you write a `T` which contains
+/// padding into `slab`, you **must not**, for example, try to read those bytes as `&[u8]` afterwards
+/// (or as some other type which expects those bytes to be initialized), as you would then be
+/// reading uninitialized memory, which is *undefined behavior*.
+///
+/// \* Validity is a complex topic not to be taken lightly.
 /// See [this rust reference page](https://doc.rust-lang.org/reference/behavior-considered-undefined.html) for more details.
 #[inline]
 pub unsafe fn get_maybe_uninit_slice_at_offset_mut_unchecked<'a, T, S: Slab>(

--- a/src/read.rs
+++ b/src/read.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::needless_lifetimes)] // important to be explicit here imo
+
 use super::*;
 
 /// Gets a shared reference to a `T` within `slab` at `offset`.


### PR DESCRIPTION
Motivated by https://github.com/Traverse-Research/gpu-allocator/pull/139, scaffolded some read-helper functions.

These helpers are mostly all unsafe and have both semi-checked and completely unchecked variants. They are relevant in either case because they lay out in documentation exactly what the needed safety requirements are to read the given data, given that we have a properly implemented `Slab`, and try to remove some common footguns (alignment, size within allocation) where possible in the checked variants.

A note for reviewers is that you can skip the `copy.rs` file as that is just code movement from the old `lib.rs`.

@eddyb, requested your review since you helped validate `presser` originally and you might have some valuable input on the safety comments/requirements here.